### PR TITLE
update template with calling contract example

### DIFF
--- a/functions/template/node/function/handler.js
+++ b/functions/template/node/function/handler.js
@@ -1,12 +1,37 @@
 "use strict"
 
+const querystring = require('querystring');
+
 const Web3 = require("web3");
 const web3 = new Web3(new Web3.providers.HttpProvider(`http://${process.env.eth_host}:8545`));
-const querystring = require('querystring');
+
+const path = require('path');
+const TruffleContract = require('truffle-contract');
+const MetaCoinJSON  = require(path.join(__dirname, 'contracts/MetaCoin.json'));
+
+const MetaCoin = TruffleContract(MetaCoinJSON);
+MetaCoin.setProvider(web3.currentProvider);
+
+// MonkeyPatch
+// https://github.com/trufflesuite/truffle-contract/issues/56#issuecomment-331084530
+if (typeof MetaCoin.currentProvider.sendAsync !== "function") {
+    MetaCoin.currentProvider.sendAsync = function() {
+        return MetaCoin.currentProvider.send.apply(MetaCoin.currentProvider, arguments);
+    };
+}
 
 module.exports = (context, callback) => {
     const body = querystring.parse(context);
+
     web3.eth.getAccounts((err, result) => {
-        callback(undefined, result);
+        MetaCoin.deployed().then((instance) => {
+            return instance.getBalance.call(accounts[0]);
+        }).catch((err) => {
+            console.log(err);
+        }).then(function(balance) {
+            callback(undefined, balance.valueOf());
+        }).catch((err) => {
+            console.log(err);
+        });
     });    
 }


### PR DESCRIPTION
1. Copy contract ABI after `truffle migrate`.

```
cp -R dapp/build/contracts functions/FUNCTION_NAME/contracts
```

2. web3.sendAsync is `unstable`.
see https://github.com/trufflesuite/truffle-contract/issues/56#issuecomment-331084530